### PR TITLE
Seeding collection from CSV

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,6 +5,7 @@ import * as game from './routes/game.js';
 import * as decks from './routes/decks.js';
 import * as actions from './routes/actions.js';
 import * as discourse from './routes/discourse.js';
+import * as hello from './routes/hello.js';
 
 const app = express();
 export const port = process.env.PORT || 8000;
@@ -18,6 +19,7 @@ app.post('/game/draw', game.draw);
 app.get('/decks', decks.get);
 app.get('/actions', actions.get);
 app.get('/discourse/links', discourse.links);
+app.get('/hello', hello.get);
 
 export default app;
 

--- a/app/models/CSVModels.js
+++ b/app/models/CSVModels.js
@@ -1,0 +1,26 @@
+import csv from 'csvtojson';
+import mongoose from '../services/mongoose.js';
+
+const name = 'inspiration'
+
+// using the one csv in the repo for now.
+// later, let this be variable.
+const file_path = `./assets/decks/${name}/${name}.csv`
+
+export const rows = await csv().fromFile(file_path);
+
+const schema_data = {}
+
+for (var header in rows[0]) {
+    schema_data[header] = String;
+}
+
+// TODO: What is this for?
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+const schema = new mongoose.Schema(
+    schema_data, { timestamps: true });
+
+const Model = mongoose.model(name, schema);
+
+export default Model

--- a/app/routes/hello.js
+++ b/app/routes/hello.js
@@ -1,0 +1,6 @@
+export async function get(req, res) {
+    const hello = {
+      'body' : 'hello world'  
+    };
+    res.json(hello);
+  }

--- a/assets/decks/inspiration/inspiration.csv
+++ b/assets/decks/inspiration/inspiration.csv
@@ -1,0 +1,21 @@
+name,link,house
+Alain Badiou,https://ceasefiremagazine.co.uk/alain-badiou-event/,
+angel Kyodo williams,https://angelkyodowilliams.com/,
+Brazilian Jiu Jitsu,,reef
+Søren Brier,https://www.cybersemiotics.com/content/what-cybersemiotics,reef
+Burning Man,,
+Contact Improvisation,,woods
+James Carse,http://wtf.tw/ref/carse.pdf,
+Louis-Bertrand Castel,https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/39678/RICHARD-DISSERTATION-2016.pdf,paradise
+Fluxus,,
+Francisco Varela,https://monoskop.org/images/3/35/Maturana_Humberto_Varela_Francisco_Autopoiesis_and_Congition_The_Realization_of_the_Living.pdf,
+Jo Freeman,https://www.jofreeman.com/joreen/tyranny.htm,
+The KLF,https://www.youtube.com/watch?v=bWebqCRw7o4,
+Hermann Hesse,,
+Maker Movement,https://en.wikipedia.org/wiki/Maker_culture,
+Open Source,,
+Seymour Papert,http://worrydream.com/refs/Papert%20-%20Mindstorms%201st%20ed.pdf,
+Gunther Teubner,https://cadmus.eui.eu/handle/1814/23894,paradise
+Shamanism,,woods
+Simone de Beauvoir,https://www.marxists.org/reference/subject/ethics/de-beauvoir/ambiguity/index.htm,
+Tai Chi,,paradise

--- a/bin/seed-csv.js
+++ b/bin/seed-csv.js
@@ -1,0 +1,29 @@
+import commander from 'commander';
+import fs from 'fs';
+import csvm from '../app/models/CSVModels.js';
+import {rows} from '../app/models/CSVModels.js';
+
+const { program } = commander;
+
+program
+// cruft templating...
+//  .option('-p, --path <string>', 'path to assets')
+//  .option('-n, --name <string>', 'deck name')
+//  .option('-d, --description <string>', 'deck description')
+  .parse(process.argv);
+
+(async () => {
+    for (var i in rows) {
+        const row = rows[i]
+        await csvm.findOneAndUpdate(
+            row, row,
+            { new: true, upsert: true, returnNewDocument: true }
+            );    
+    }
+    
+    process.exit();
+})().catch(console.error)
+.then((e) => {
+    console.log(e);
+    process.exit();
+});


### PR DESCRIPTION
This PR is work towards a new feature idea.

Currently, 'Cards' have a fixed schema shared across all decks, and the CSV data for all decks is combined into one file.

A somewhat more flexible design would have each deck's "single source of truth" be its own CSV file, whose column headers (and data types?) provide the schema.

This seems to fit the usage of Mongo as a 'document DB' quite well.

I see that it's quite trivial to import CSV as a collection in Mongo Compass.

I think what I'm going for here is for that operation to be easily handled from the build environment/CLI.

I have not touched the existing Card/action code in this PR, but I do want to poke in the design direction of cards "[duck typing](https://realpython.com/lessons/duck-typing/#:~:text=Duck%20typing%20is%20a%20concept,a%20given%20method%20or%20attribute.)" into different functionality.

Requesting review from @benheller 