### PR TITLE
[WIP] links for cards

### DIFF
--- a/app/models/Card.js
+++ b/app/models/Card.js
@@ -8,6 +8,7 @@ const schema = new mongoose.Schema({
   image: String,
   reverse: String,
   suit: String,
+  link: String,
   deck: {
     type: ObjectId, 
     ref: 'Deck'

--- a/app/services/discord/draw.js
+++ b/app/services/discord/draw.js
@@ -41,6 +41,10 @@ export default async function draw(message, opt) {
       card.name += ' (Reversed)';
       card.description = card.reverse;
     }
+
+    if (card.link) {
+      card.description = `[${card.description}](${card.link})`
+    }
   } catch (err) {
     return message.reply('Could not draw a card! Try selecting another deck or starting a new game with `!new`');
   }


### PR DESCRIPTION
This PR addresses #22 adding links for cards.

In the current implementation, cards with link data will have their descriptions hyperlinked to the link URL in the Discord response.

However, this PR is not complete because there is no card data column to support it.

This will require edits to the card file. This should probably wait until #11 has been resolved so that it's easier to migrate the live DB before a lot of CSV schema changes are made.