### PR TITLE
Functioning subset of Oblique Strategies deck

### DIFF
--- a/app/discord/draw.js
+++ b/app/discord/draw.js
@@ -48,9 +48,16 @@ export default async function draw(message, opt) {
   }
 
   log.debug(`PGBG: ${message.author.username} drew the ${card.name} from ${opt} - ${card.image}`);
-    
   // build the message
-  const image = await images.draw(`./assets/decks/${opt.toLowerCase()}/${card.image}`, reversed ? 180 : 0);
+  var image;
+  if (card.file) {
+    image = await images.draw(
+      `./assets/decks/${opt.toLowerCase()}/${card.image}`,
+      reversed ? 180 : 0);
+  } else {
+    image = await images.write(card.name);
+  }
+
   const attachment = new Discord.MessageAttachment(image, card.image);
   const embed = new Discord.MessageEmbed()
     .setTitle(card.name)

--- a/app/services/images.js
+++ b/app/services/images.js
@@ -21,3 +21,16 @@ export async function draw(path, rotate) {
 
   return canvas.toBuffer();
 }
+
+export async function write(words) {
+  const canvas = Canvas.createCanvas(400, 400);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = 'black';
+  ctx.font = '16px Arial';
+  ctx.fillText(words, 250 - words.length * 5, 240);
+  
+  return canvas.toBuffer();
+}

--- a/assets/decks/oblique.csv
+++ b/assets/decks/oblique.csv
@@ -1,0 +1,3 @@
+Deck,Directory,Suit,Name,Description
+Oblique,Oblique/, Strategies, Accretion,.
+Oblique,Oblique/, Strategies, You are an engineer.,.

--- a/bin/seed-db.js
+++ b/bin/seed-db.js
@@ -28,6 +28,10 @@ const decks = [{
   path: 'assets/decks/archetopics',
   name: 'Archetopics',
   description: 'Regenaissance Sigils'
+}, {
+  path: 'assets/decks/oblique',
+  name: 'Oblique',
+  description: 'Oblique Strategies by Brian Eno'
 }];
 
 for (const deck of decks) {


### PR DESCRIPTION
This PR implements a prototype version of an Oblique Strategies deck, see #40.

Several changes are included in this PR:
 - Data for 2 cards of the Oblique deck have 
 - The seed:deck script used to loop through the file directory for each deck. Since the Oblique deck has no images, this had to be changed. Now the script reads and loops through the CSV file for each deck.
 - The `images.js` service now has a `write()` method for printing text to an image (via a canvas buffer). This is used when there is no file available for a card

Together, these changes partially implement Oblique Strategies. Because of the core functionality changes to seed:deck, I want to submit this PR for review at this stage.

Future work to complete #40, not included in this PR, will involve supplying the complete deck data.
It will also require work on sizing and spacing the text properly in the `images.js` `write()` command.